### PR TITLE
Full reversal

### DIFF
--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -238,6 +238,11 @@ export default class CoT {
             geojson.properties.remarks = raw.event.detail.remarks._text;
         }
 
+        if (raw.event.detail.track && raw.event.detail.track._attributes) {
+            if (raw.event.detail.track._attributes.course) geojson.properties.course = Number(raw.event.detail.track._attributes.course);
+            if (raw.event.detail.track._attributes.course) geojson.properties.speed = Number(raw.event.detail.track._attributes.speed);
+        }
+
         return geojson;
     }
 

--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -243,6 +243,10 @@ export default class CoT {
             if (raw.event.detail.track._attributes.course) geojson.properties.speed = Number(raw.event.detail.track._attributes.speed);
         }
 
+        if (raw.event.detail.usericon && raw.event.detail.usericon._attributes && raw.event.detail.usericon._attributes.iconsetpath) {
+            geojson.properties.icon = raw.event.detail.usericon._attributes.iconsetpath;
+        }
+
         return geojson;
     }
 

--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -141,6 +141,8 @@ export default class CoT {
             }
         }
 
+        cot.event.detail.remarks = { _attributes: { }, _text: feature.properties.remarks || '' };
+
         if (!feature.geometry) throw new Error('Must have Geometry');
         if (!['Point', 'Polygon', 'LineString'].includes(feature.geometry.type)) throw new Error('Unsupported Geometry Type');
 
@@ -192,8 +194,6 @@ export default class CoT {
             cot.event.detail.labels_on = { _attributes: { value: 'false' } };
             cot.event.detail.tog = { _attributes: { enabled: '0' } };
 
-            cot.event.detail.remarks = { _attributes: { }, _text: feature.properties.remarks || '' };
-
             const centre = PointOnFeature(feature as AllGeoJSON);
             cot.event.point._attributes.lon = String(centre.geometry.coordinates[0]);
             cot.event.point._attributes.lat = String(centre.geometry.coordinates[1]);
@@ -220,7 +220,7 @@ export default class CoT {
                 how: raw.event._attributes.how,
                 time: raw.event._attributes.time,
                 start: raw.event._attributes.start,
-                stale: raw.event._attributes.stale
+                stale: raw.event._attributes.stale,
             },
             geometry: {
                 type: 'Point',
@@ -231,6 +231,12 @@ export default class CoT {
                 ]
             }
         };
+
+        if (!geojson.properties) geojson.properties = {};
+
+        if (raw.event.detail.remarks && raw.event.detail.remarks._text) {
+            geojson.properties.remarks = raw.event.detail.remarks._text;
+        }
 
         return geojson;
     }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -120,7 +120,7 @@ export default class Util {
                 start: (new Date(start || now)).toISOString(),
                 stale: (new Date(new Date(start || now).getTime() + 20 * 1000)).toISOString()
             };
-        } else if (!isNaN(parseInt(String(stale)))) {
+        } else if (typeof stale === 'number') {
             return {
                 time: (new Date(time || now)).toISOString(),
                 start: (new Date(start || now)).toISOString(),

--- a/test/cot-itak.test.ts
+++ b/test/cot-itak.test.ts
@@ -51,7 +51,9 @@ test('Decode iTAK COT message', (t) => {
             how: 'm-g',
             time: '2023-07-18T15:23:09.00Z',
             start: '2023-07-18T15:23:09.00Z',
-            stale: '2023-07-18T15:25:09.00Z'
+            stale: '2023-07-18T15:25:09.00Z',
+            course: 137.23542786,
+            speed: 0
         },
         geometry: {
             type: 'Point',

--- a/test/fixtures/basic.geojson
+++ b/test/fixtures/basic.geojson
@@ -1,0 +1,16 @@
+{
+    "id": "123",
+    "type": "Feature",
+    "properties": {
+        "type": "a-f-G",
+        "how": "m-g",
+        "callsign": "BasicTest",
+        "time": "2023-08-04T15:17:43.649Z",
+        "start": "2023-08-04T15:17:43.649Z",
+        "stale": "2023-08-04T15:17:43.649Z"
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [1.1, 2.2, 0]
+    }
+}

--- a/test/fixtures/hae.json
+++ b/test/fixtures/hae.json
@@ -1,0 +1,16 @@
+{
+    "id": "123",
+    "type": "Feature",
+    "properties": {
+        "type": "a-f-G",
+        "how": "m-g",
+        "callsign": "BasicTest",
+        "time": "2023-08-04T15:17:43.649Z",
+        "start": "2023-08-04T15:17:43.649Z",
+        "stale": "2023-08-04T15:17:43.649Z"
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [1.1, 2.2, 1234]
+    }
+}

--- a/test/fixtures/icon.geojson
+++ b/test/fixtures/icon.geojson
@@ -1,0 +1,17 @@
+{
+    "id": "123",
+    "type": "Feature",
+    "properties": {
+        "type": "a-f-G",
+        "how": "m-g",
+        "callsign": "BasicTest",
+        "time": "2023-08-04T15:17:43.649Z",
+        "start": "2023-08-04T15:17:43.649Z",
+        "stale": "2023-08-04T15:17:43.649Z",
+        "icon": "iconset/test.png"
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [1.1, 2.2, 0]
+    }
+}

--- a/test/fixtures/props.geojson
+++ b/test/fixtures/props.geojson
@@ -8,7 +8,9 @@
         "time": "2023-08-04T15:17:43.649Z",
         "start": "2023-08-04T15:17:43.649Z",
         "stale": "2023-08-04T15:17:43.649Z",
-        "remarks": "test-remarks"
+        "remarks": "test-remarks",
+        "course": 260,
+        "speed": 120
     },
     "geometry": {
         "type": "Point",

--- a/test/fixtures/props.geojson
+++ b/test/fixtures/props.geojson
@@ -1,0 +1,17 @@
+{
+    "id": "123",
+    "type": "Feature",
+    "properties": {
+        "type": "a-f-G",
+        "how": "m-g",
+        "callsign": "BasicTest",
+        "time": "2023-08-04T15:17:43.649Z",
+        "start": "2023-08-04T15:17:43.649Z",
+        "stale": "2023-08-04T15:17:43.649Z",
+        "remarks": "test-remarks"
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [1.1, 2.2, 0]
+    }
+}

--- a/test/from_geojson.test.ts
+++ b/test/from_geojson.test.ts
@@ -24,7 +24,8 @@ test('CoT.from_geojson - Point', (t) => {
     });
 
     t.deepEquals(geo.raw.event.detail, {
-        contact: { _attributes: { callsign: 'UNKNOWN' } }
+        contact: { _attributes: { callsign: 'UNKNOWN' } },
+        remarks: { _attributes: {}, _text: '' }
     });
 
     t.end();
@@ -197,7 +198,7 @@ test('CoT.from_geojson - Icon', (t) => {
 
     t.deepEquals(geo.raw.event.detail, {
         contact: { _attributes: { callsign: 'UNKNOWN' } },
-        usericon: { _attributes: { iconsetpath: '66f14976-4b62-4023-8edb-d8d2ebeaa336/Public Safety Air/EMS_ROTOR.png' } }
+        usericon: { _attributes: { iconsetpath: '66f14976-4b62-4023-8edb-d8d2ebeaa336/Public Safety Air/EMS_ROTOR.png' } }, remarks: { _attributes: {}, _text: '' }
     });
 
     t.end();
@@ -272,11 +273,9 @@ test('CoT.from_geojson - Remarks', (t) => {
             type: 'Point',
             coordinates: [1.1, 2.2]
         }
-    }).raw.event.detail.track, {
-        _attributes: {
-            'course': '260',
-            'speed': '120'
-        }
+    }).raw.event.detail.remarks, {
+        _attributes: {},
+        _text: 'Test'
     }, 'track');
 
     t.end();

--- a/test/reversal.test.ts
+++ b/test/reversal.test.ts
@@ -8,12 +8,9 @@ import { fileURLToPath } from 'node:url';
 test('Reversal Tests', async (t) => {
     for (let fixturename of await fs.readdir(new URL('./fixtures/', import.meta.url))) {
         const fixture: Feature = JSON.parse(String(await fs.readFile(path.join(path.parse(fileURLToPath(import.meta.url)).dir, 'fixtures/', fixturename))));
-
         const geo = CoT.from_geojson(fixture)
-
         const output = geo.to_geojson();
-
-        t.deepEquals(fixture, output);
+        t.deepEquals(fixture, output, fixturename);
     }
 
     t.end();

--- a/test/reversal.test.ts
+++ b/test/reversal.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'tape';
+import CoT from '../index.js';
+import { Feature } from 'geojson'
+import { fileURLToPath } from 'node:url';
+
+test('Reversal Tests', async (t) => {
+    for (let fixturename of await fs.readdir(new URL('./fixtures/', import.meta.url))) {
+        const fixture: Feature = JSON.parse(String(await fs.readFile(path.join(path.parse(fileURLToPath(import.meta.url)).dir, 'fixtures/', fixturename))));
+
+        const geo = CoT.from_geojson(fixture)
+
+        const output = geo.to_geojson();
+
+        t.deepEquals(fixture, output);
+    }
+
+    t.end();
+});


### PR DESCRIPTION
### Context

The `from_geojson` function has a fairly wide variety of options for setting CoT properties however the functionality isn't perfectly duplicated in the `to_geojson` function. This adds a test framework for ensuring this distinction is reduced and eventually eliminated. 

- Add Course Parity
- Add Speed Parity
- Add Remarks Parity and fix bug in remarks parsing
- Add HAE Parity
- Add Icon Parity
- 