### PR TITLE
Protobuf Support

### DIFF
--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -360,7 +360,7 @@ export default class CoT {
 
         for (const key in detail) {
             if(['contact', 'group', 'precisionlocation', 'status', 'takv', 'track'].includes(key)) {
-                msg.detail.contact = detail[key]._attributes;
+                msg.detail[key] = detail[key]._attributes;
                 delete detail[key]
             }
         }
@@ -383,7 +383,7 @@ export default class CoT {
         const msg: any = ProtoMessage.decode(raw);
 
         const detail: Record<any, any> = {};
-        let metadata: Record<string, unknown> = {};
+        const metadata: Record<string, unknown> = {};
         for (const key in msg.detail) {
             if (key === 'xmlDetail') {
                 const parsed: any = xmljs.xml2js(`<detail>${msg.detail.xmlDetail}</detail>`, { compact: true });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,6 +6,10 @@ export const EventAttributes = Type.Object({
     type: Type.String(),
     how: Type.Optional(Type.String()),
 
+    access: Type.Optional(Type.String()),
+    qos: Type.Optional(Type.String()),
+    opex: Type.Optional(Type.String()),
+
     time: Type.String(),
     stale: Type.String(),
     start: Type.String(),
@@ -35,6 +39,12 @@ export const LinkAttributes = Type.Object({
 export const Link = Type.Object({
     _attributes: LinkAttributes
 })
+
+export const ProtocolSupportAttributes = Type.Object({
+    _attributes: Type.Optional(Type.Object({
+        version: Type.Optional(Type.String())
+    }))
+});
 
 export const ServerVersionAttributes = Type.Object({
     _attributes: Type.Optional(Type.Object({
@@ -235,6 +245,7 @@ export const Detail = Type.Object({
     takv: Type.Optional(TakVersion),
     marti: Type.Optional(Marti),
     TakControl: Type.Optional(Type.Object({
+        TakProtocolSupport: Type.Optional(ProtocolSupportAttributes),
         TakServerVersionInfo: Type.Optional(ServerVersionAttributes)
     }))
 })
@@ -252,7 +263,7 @@ export const Point = Type.Object({
 export default Type.Object({
     event: Type.Object({
         _attributes: EventAttributes,
-        detail: Type.Optional(Detail),
+        detail: Type.Optional(Type.Index(Detail, Type.KeyOf(Detail))),
         point: Point,
     }),
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "archiver": "^7.0.1",
                 "color": "^4.2.3",
                 "json-diff-ts": "^4.0.1",
-                "protobufjs": "^7.1.2",
+                "protobufjs": "^7.3.0",
                 "xml-js": "^1.6.11"
             },
             "devDependencies": {
@@ -3254,9 +3254,9 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/protobufjs": {
-            "version": "7.2.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-            "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+            "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
             "hasInstallScript": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "archiver": "^7.0.1",
         "color": "^4.2.3",
         "json-diff-ts": "^4.0.1",
-        "protobufjs": "^7.1.2",
+        "protobufjs": "^7.3.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {

--- a/test/reversal-geojson.test.ts
+++ b/test/reversal-geojson.test.ts
@@ -1,0 +1,18 @@
+import { Static } from '@sinclair/typebox';
+import { Feature } from '../lib/feature.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import test from 'tape';
+import CoT from '../index.js';
+import { fileURLToPath } from 'node:url';
+
+for (const fixturename of await fs.readdir(new URL('./fixtures/', import.meta.url))) {
+    test(`GeoJSON Reversal Tests: ${fixturename}`, async (t) => {
+        const fixture: Static<typeof Feature> = JSON.parse(String(await fs.readFile(path.join(path.parse(fileURLToPath(import.meta.url)).dir, 'fixtures/', fixturename))));
+        const geo = CoT.from_geojson(fixture)
+        const output = geo.to_geojson();
+        t.deepEquals(fixture, output, fixturename);
+
+        t.end();
+    });
+}

--- a/test/reversal-proto.test.ts
+++ b/test/reversal-proto.test.ts
@@ -6,13 +6,14 @@ import test from 'tape';
 import CoT from '../index.js';
 import { fileURLToPath } from 'node:url';
 
-test('Reversal Tests', async (t) => {
-    for (const fixturename of await fs.readdir(new URL('./fixtures/', import.meta.url))) {
+for (const fixturename of await fs.readdir(new URL('./fixtures/', import.meta.url))) {
+    test(`Protobuf Reversal Tests: ${fixturename}`, async (t) => {
         const fixture: Static<typeof Feature> = JSON.parse(String(await fs.readFile(path.join(path.parse(fileURLToPath(import.meta.url)).dir, 'fixtures/', fixturename))));
         const geo = CoT.from_geojson(fixture)
-        const output = geo.to_geojson();
-        t.deepEquals(output, fixture, fixturename);
-    }
+        const intermediate = geo.to_proto();
+        const output = CoT.from_proto(intermediate);
+        t.deepEquals(fixture, output.to_geojson(), fixturename);
 
-    t.end();
-});
+        t.end();
+    });
+}


### PR DESCRIPTION
### Context

Add V1 Protobuf support derived from ATAK Proto files.

Protobuf support in the PR is in a very early form and hasn't been tested using production data. Current unit/integration tests are based around ensuring 100% identical message output after a round trip to and then from protobuf.
