### PR TITLE
handle 0-length polyline

### DIFF
--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -152,14 +152,14 @@ export const VertexAttribute = Type.Object({
 
 export const ShapePolyLine = Type.Object({
     _attributes: Type.Optional(ShapePolyLineAttributes),
-    vertex: Type.Union([
+    vertex: Type.Optional(Type.Union([
         Type.Object({
             _attributes: VertexAttribute
         }),
         Type.Array(Type.Object({
             _attributes: VertexAttribute
         }))
-    ])
+    ]))
 })
 
 export const ShapeEllipseAttributes = Type.Object({

--- a/test/cot-polyline.test.ts
+++ b/test/cot-polyline.test.ts
@@ -1,0 +1,103 @@
+import test from 'tape';
+import CoT from '../index.js';
+
+test('En-decode polyline', (t) => {
+    const cot = new CoT({
+        "event": {
+            "_attributes": {
+                "version": "2.0",
+                "uid": "ebbf42a7-ea71-43a1-baf6-e259c3d115bf",
+                "type": "u-rb-a",
+                "how": "h-e",
+                "time": "2024-08-30T22:28:02Z",
+                "start": "2024-08-30T22:28:02Z",
+                "stale": "2024-08-31T22:28:02Z",
+                "access": "Undefined"
+            },
+            "point": {
+                "_attributes": {
+                    "lat": "39.0981196",
+                    "lon": "-108.7395013",
+                    "hae": "0.0",
+                    "ce": "9999999.0",
+                    "le": "9999999.0"
+                }
+            },
+            "detail": {
+                "contact": {
+                    "_attributes": {
+                        "callsign": "c"
+                    }
+                },
+                "shape": {
+                    "polyline": {
+                      "vertex": [
+                        { "_attributes": { "lat": 47.7047674, "lon": -122.17861 } },
+                        {
+                          "_attributes": { "lat": 47.71376061012636, "lon": -122.17861 }
+                        },
+                        {
+                          "_attributes": { "lat": 47.7047674, "lon": -122.16524615319642 }
+                        },
+                        {
+                          "_attributes": { "lat": 47.695774189873646, "lon": -122.17861 }
+                        },
+                        { "_attributes": { "lat": 47.7047674, "lon": -122.17861 } }
+                      ],
+                      "_attributes": { "closed": true }
+                    }
+                }
+           }
+        }
+    })
+
+    const cot2 = CoT.from_proto(cot.to_proto())
+    const vertex = cot2.raw.event.detail?.shape?.polyline?.vertex
+    t.ok(Array.isArray(vertex) && vertex.length === 5)
+
+    t.end();
+});
+
+test('En-decode 0-length polyline', (t) => {
+    const cot3 = new CoT({
+        "event": {
+            "_attributes": {
+                "version": "2.0",
+                "uid": "ebbf42a7-ea71-43a1-baf6-e259c3d115bf",
+                "type": "u-rb-a",
+                "how": "h-e",
+                "time": "2024-08-30T22:28:02Z",
+                "start": "2024-08-30T22:28:02Z",
+                "stale": "2024-08-31T22:28:02Z",
+                "access": "Undefined"
+            },
+            "point": {
+                "_attributes": {
+                    "lat": "39.0981196",
+                    "lon": "-108.7395013",
+                    "hae": "0.0",
+                    "ce": "9999999.0",
+                    "le": "9999999.0"
+                }
+            },
+            "detail": {
+                "contact": {
+                    "_attributes": {
+                        "callsign": "c"
+                    }
+                },
+                "shape": {
+                    "polyline": {
+                      "vertex": [],
+                    }
+                }
+           }
+        }
+    })
+
+    // xml en-decoding looses empty array, but should work. 
+    const cot4 = CoT.from_proto(cot3.to_proto())
+    t.ok(cot4.raw.event.detail?.shape?.polyline)
+
+    t.end();
+});


### PR DESCRIPTION
Before this en+decoding a 0-length polyline failed.

This is relevant, because it is the only way to get ATAK to remove a polyline if you no longer need it (without deleting the CoT).

Change-Id: I55670245d12e76bd968b7a66da91fd255078c67f