### PR TITLE
Cleanup DataPackage

### DIFF
--- a/lib/data-package.ts
+++ b/lib/data-package.ts
@@ -198,14 +198,17 @@ export class DataPackage {
      * @param input path to zipped DataPackage on disk
      * @param [opts] Parser Options
      * @param [opts.strict] By default the DataPackage must contain a manifest file, turning strict mode off will generate a manifest based on the contents of the file
+     * @param [opts.cleanup] If the Zip is parsed as a DataSync successfully, remove the initial zip file
      */
     static async parse(input: string | URL, opts?: {
         strict?: boolean
+        cleanup?: boolean
     }): Promise<DataPackage> {
         input = input instanceof URL ? decodeURIComponent(input.pathname) : input;
 
         if (!opts) opts = {};
         if (opts.strict === undefined) opts.strict = true;
+        if (opts.cleanup === undefined) opts.cleanup = true;
 
         const pkg = new DataPackage();
 
@@ -263,6 +266,11 @@ export class DataPackage {
                     await pkg.hash(key)
                 );
             }
+        }
+
+        await zip.close();
+        if (opts.cleanup) {
+            await fsp.unlink(input);
         }
 
         return pkg;

--- a/test/cot-fileshare.test.ts
+++ b/test/cot-fileshare.test.ts
@@ -1,7 +1,7 @@
 import test from 'tape';
-import CoT from '../index.js';
+import CoT, { FileShare, DataPackage } from '../index.js';
 
-test('Decode MultiMissionAircraft CoTs', (t) => {
+test('FileShare COT', (t) => {
     const cot = new CoT({"event":{"_attributes":{"version":"2.0","uid":"d60e38c2-6c51-4f69-bff9-c5cbc6b44a76","type":"b-f-t-r","how":"h-e","time":"2024-07-02T17:13:20Z","start":"2024-07-02T17:13:19Z","stale":"2024-07-02T17:13:29Z"},"point":{"_attributes":{"lat":"39.07853","lon":"-108.537397","hae":"1400.49561947","ce":"9.9350462","le":"NaN"}},"detail":{"fileshare":{"_attributes":{"filename":"20240615_144641.jpg.zip","senderUrl":"https://18.254.242.65:8443/Marti/sync/content?hash=c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e","sizeInBytes":"4233884","sha256":"c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e","senderUid":"ANDROID-0ca41830e11d2ef3","senderCallsign":"DFPC Ingalls","name":"20240615_144641.jpg"}},"ackrequest":{"_attributes":{"uid":"814d0d4a-3339-4fd2-8e09-0556444112f3","ackrequested":"true","tag":"20240615_144641.jpg"}},"_flow-tags_":{"_attributes":{"TAK-Server-e87a0e02420b44a08f6032bcf1877745":"2024-07-02T17:13:20Z"}}}}});
 
     if (!cot.raw.event.detail) {
@@ -31,23 +31,23 @@ test('Decode MultiMissionAircraft CoTs', (t) => {
                     }
                 },
                 "detail":{
-                    ackrequest: {                                                                                                                                                
-                        "_attributes": {                                                                                                                                           
-                            "uid": "814d0d4a-3339-4fd2-8e09-0556444112f3",                     
-                            "ackrequested": true,                                                                                                                                  
-                            "tag": "20240615_144641.jpg"                                                                                                                             
-                        }                                                                    
+                    ackrequest: {
+                        "_attributes": {
+                            "uid": "814d0d4a-3339-4fd2-8e09-0556444112f3",
+                            "ackrequested": true,
+                            "tag": "20240615_144641.jpg"
+                        }
                     },
-                    fileshare: {                                                                                                                                                 
-                        "_attributes": {                                                                                                                                           
-                            "filename": "20240615_144641.jpg.zip",                             
-                            "senderUrl": "https://18.254.242.65:8443/Marti/sync/content?hash=c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e",                      
-                            "sizeInBytes": 4233884,                                                                                                                                
-                            "sha256": "c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e",                                                                            
-                            "senderUid": "ANDROID-0ca41830e11d2ef3",                           
-                            "senderCallsign": "DFPC Ingalls",                                                                                                                        
-                            "name": "20240615_144641.jpg"                                                                                                                            
-                        }                                                                    
+                    fileshare: {
+                        "_attributes": {
+                            "filename": "20240615_144641.jpg.zip",
+                            "senderUrl": "https://18.254.242.65:8443/Marti/sync/content?hash=c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e",
+                            "sizeInBytes": 4233884,
+                            "sha256": "c18e00d123057a8e33107e91ab02f999ecc6f849aed2a41b84e237ff36106a4e",
+                            "senderUid": "ANDROID-0ca41830e11d2ef3",
+                            "senderCallsign": "DFPC Ingalls",
+                            "name": "20240615_144641.jpg"
+                        }
                     }
                 }
             }
@@ -65,10 +65,10 @@ test('Decode MultiMissionAircraft CoTs', (t) => {
                 time: '2024-07-02T17:13:20Z',
                 start: '2024-07-02T17:13:19Z',
                 stale: '2024-07-02T17:13:29Z',
-                ackrequest: {                                                                                                                                                
-                    "uid": "814d0d4a-3339-4fd2-8e09-0556444112f3",                     
-                    "ackrequested": true,                                                                                                                                  
-                    "tag": "20240615_144641.jpg"                                                                                                                             
+                ackrequest: {
+                    "uid": "814d0d4a-3339-4fd2-8e09-0556444112f3",
+                    "ackrequested": true,
+                    "tag": "20240615_144641.jpg"
                 },
                 fileshare: {
                     "filename": "20240615_144641.jpg.zip",
@@ -90,3 +90,25 @@ test('Decode MultiMissionAircraft CoTs', (t) => {
 
     t.end();
 });
+
+test('FileShare DataPackage', async (t) => {
+    const fileshare = new FileShare({
+        filename: 'large-file.zip',
+        name: 'large-file',
+        senderCallsign: 'MCSAR Ingalls',
+        senderUid: 'ANDROID-123',
+        senderUrl: 'https://raw.githubusercontent.com/mapbox/Simple-KML/refs/heads/master/sample/example.kml',
+        sha256: 'sha-123',
+        sizeInBytes: 1234
+    })
+
+    const pkg = new DataPackage();
+
+    pkg.addCoT(fileshare);
+
+    const path = await pkg.finalize();
+
+    console.error(path);
+
+    t.end();
+})

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -4,7 +4,9 @@ import fs from 'node:fs';
 import test from 'tape';
 
 test(`DataPackage CoT Parsing: CameraCOTs.zip`, async (t) => {
-    const pkg = await DataPackage.parse(new URL('./packages/CameraCOTs.zip', import.meta.url).pathname);
+    const pkg = await DataPackage.parse(new URL('./packages/CameraCOTs.zip', import.meta.url).pathname, {
+        cleanup: false
+    });
 
     t.equals(pkg.version, '2');
     t.ok(pkg.path);
@@ -137,7 +139,9 @@ test(`DataPackage CoT Writing`, async (t) => {
 });
 
 test(`DataPackage CoT Parsing: QuickPic.zip`, async (t) => {
-    const pkg = await DataPackage.parse(new URL('./packages/QuickPic.zip', import.meta.url).pathname);
+    const pkg = await DataPackage.parse(new URL('./packages/QuickPic.zip', import.meta.url).pathname, {
+        cleanup: false
+    });
 
     t.equals(await DataPackage.hash(new URL('./packages/QuickPic.zip', import.meta.url).pathname), 'bd13db0f18ccb423833cc21c0678e0224dd15ff504c1f16c43aff03e216b82a7');
 
@@ -272,7 +276,9 @@ test(`DataPackage CoT Parsing: AttachmentInManifest.zip`, async (t) => {
 });
 
 test(`DataPackage File Parsing: COMileposts.zip`, async (t) => {
-    const pkg = await DataPackage.parse(new URL('./packages/COMilePosts.zip', import.meta.url).pathname);
+    const pkg = await DataPackage.parse(new URL('./packages/COMilePosts.zip', import.meta.url).pathname, {
+        cleanup: false
+    });
 
     t.equals(await DataPackage.hash(new URL('./packages/COMilePosts.zip', import.meta.url).pathname), '118e6b6f4cd30c855606879263f6376ca8a6f9b1694dd38ac43868ecfbe46edb');
 
@@ -315,7 +321,8 @@ test(`DataPackage File Parsing: COMileposts.zip`, async (t) => {
 
 test(`DataPackage File Parsing: Iconset-FalconView.zip (strict: false)`, async (t) => {
     const pkg = await DataPackage.parse(new URL('./packages/Iconset-FalconView.zip', import.meta.url).pathname, {
-        strict: false
+        strict: false,
+        cleanup: false
     });
 
     t.equals(await DataPackage.hash(new URL('./packages/Iconset-FalconView.zip', import.meta.url).pathname), '53622c90841d2ef66b3b508412be0ecd33f90f1cd7887295ab0c3a31ee2e7315');
@@ -352,7 +359,8 @@ test(`DataPackage File Parsing: Iconset-FalconView.zip (strict: false)`, async (
 
 test(`MissionArchive: Testing Export`, async (t) => {
     const pkg = await DataPackage.parse(new URL('./packages/MissionArchive.zip', import.meta.url).pathname, {
-        strict: false
+        strict: false,
+        cleanup: false
     });
 
     t.equals(

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -223,7 +223,9 @@ test(`DataPackage CoT Parsing: addFile,getFile`, async (t) => {
 });
 
 test(`DataPackage CoT Parsing: AttachmentInManifest.zip`, async (t) => {
-    const pkg = await DataPackage.parse(new URL('./packages/AttachmentInManifest.zip', import.meta.url).pathname);
+    const pkg = await DataPackage.parse(new URL('./packages/AttachmentInManifest.zip', import.meta.url).pathname, {
+        cleanup: false
+    });
 
     t.equals(await DataPackage.hash(new URL('./packages/AttachmentInManifest.zip', import.meta.url).pathname), '313127964ac117dfbe6d64bb8a0832182593348692df3b8f9f9448d9f91c289e');
 


### PR DESCRIPTION
### Context

Ensure the zip reader is explicitly closed when `DataPackage.parse` is called and cleanup/remove the initial zip by default via new `opt.cleanup`