### PR TITLE
bugfix: platform agnostic path generation

### DIFF
--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -33,11 +33,14 @@ import Color from './utils/color.js';
 import JSONCoT, { Detail } from './types/types.js'
 import AJV from 'ajv';
 import fs from 'fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // GeoJSON Geospatial ops will truncate to the below
 const COORDINATE_PRECISION = 6;
 
-const RootMessage = await protobuf.load(new URL('./proto/takmessage.proto', import.meta.url).pathname);
+const protoPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'proto', 'takmessage.proto');
+const RootMessage = await protobuf.load(protoPath);
 
 const pkg = JSON.parse(String(fs.readFileSync(new URL('../package.json', import.meta.url))));
 

--- a/lib/data-package.ts
+++ b/lib/data-package.ts
@@ -204,8 +204,7 @@ export class DataPackage {
         strict?: boolean
         cleanup?: boolean
     }): Promise<DataPackage> {
-        input = input instanceof URL ? decodeURIComponent(input.pathname) : input;
-
+        input = input instanceof URL ? path.normalize(decodeURIComponent(input.pathname)) : input;
         if (!opts) opts = {};
         if (opts.strict === undefined) opts.strict = true;
         if (opts.cleanup === undefined) opts.cleanup = true;


### PR DESCRIPTION
Fixed a bug where on CoT root message generation and on Data Package parsing, using node's built-in `.pathname` function would prepend a prefix on Windows systems (this is a non-issue for UNIX), causing compilation errors for users who intend to use this on Windows.

Fixes [#61]