### PR TITLE
Change Stale Calc Default

### DIFF
--- a/lib/utils/util.ts
+++ b/lib/utils/util.ts
@@ -61,7 +61,7 @@ export default class Util {
      */
     static cot_track_attr(course?: number, speed?: number, slope?: number): Static<typeof TrackAttributes> {
         const attr: Static<typeof TrackAttributes> = {};
- 
+
         if (course) attr.course = String(course);
         if (speed) attr.speed = String(speed);
         if (slope) attr.slope = String(slope);
@@ -122,13 +122,13 @@ export default class Util {
             return {
                 time: (new Date(time || now)).toISOString(),
                 start: (new Date(start || now)).toISOString(),
-                stale: (new Date(new Date(start || now).getTime() + 20 * 1000)).toISOString()
+                stale: (new Date(new Date(now).getTime() + 20 * 1000)).toISOString()
             };
         } else if (typeof stale === 'number') {
             return {
                 time: (new Date(time || now)).toISOString(),
                 start: (new Date(start || now)).toISOString(),
-                stale: (new Date(new Date(start || now).getTime() + Number(stale))).toISOString()
+                stale: (new Date(new Date(now).getTime() + Number(stale))).toISOString()
             };
         } else {
             return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,9 +1046,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.15.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-            "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+            "version": "22.15.24",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
+            "integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -1116,17 +1116,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-            "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.0.tgz",
+            "integrity": "sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.32.1",
-                "@typescript-eslint/type-utils": "8.32.1",
-                "@typescript-eslint/utils": "8.32.1",
-                "@typescript-eslint/visitor-keys": "8.32.1",
+                "@typescript-eslint/scope-manager": "8.33.0",
+                "@typescript-eslint/type-utils": "8.33.0",
+                "@typescript-eslint/utils": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -1140,7 +1140,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "@typescript-eslint/parser": "^8.33.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
@@ -1156,16 +1156,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-            "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
+            "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.32.1",
-                "@typescript-eslint/types": "8.32.1",
-                "@typescript-eslint/typescript-estree": "8.32.1",
-                "@typescript-eslint/visitor-keys": "8.32.1",
+                "@typescript-eslint/scope-manager": "8.33.0",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/typescript-estree": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1180,15 +1180,16 @@
                 "typescript": ">=4.8.4 <5.9.0"
             }
         },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-            "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
+            "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.32.1",
-                "@typescript-eslint/visitor-keys": "8.32.1"
+                "@typescript-eslint/tsconfig-utils": "^8.33.0",
+                "@typescript-eslint/types": "^8.33.0",
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1198,15 +1199,50 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-            "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
+            "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.32.1",
-                "@typescript-eslint/utils": "8.32.1",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
+            "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.0.tgz",
+            "integrity": "sha512-lScnHNCBqL1QayuSrWeqAL5GmqNdVUQAAMTaCwdYEdWfIrSrOGzyLGRCHXcCixa5NK6i5l0AfSO2oBSjCjf4XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.33.0",
+                "@typescript-eslint/utils": "8.33.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -1223,9 +1259,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-            "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+            "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1237,14 +1273,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-            "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
+            "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.32.1",
-                "@typescript-eslint/visitor-keys": "8.32.1",
+                "@typescript-eslint/project-service": "8.33.0",
+                "@typescript-eslint/tsconfig-utils": "8.33.0",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/visitor-keys": "8.33.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1290,16 +1328,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-            "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.0.tgz",
+            "integrity": "sha512-lPFuQaLA9aSNa7D5u2EpRiqdAUhzShwGg/nhpBlc4GR6kcTABttCuyjFs8BcEZ8VWrjCBof/bePhP3Q3fS+Yrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.32.1",
-                "@typescript-eslint/types": "8.32.1",
-                "@typescript-eslint/typescript-estree": "8.32.1"
+                "@typescript-eslint/scope-manager": "8.33.0",
+                "@typescript-eslint/types": "8.33.0",
+                "@typescript-eslint/typescript-estree": "8.33.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1314,13 +1352,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-            "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
+            "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.32.1",
+                "@typescript-eslint/types": "8.33.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -2216,9 +2254,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.10",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.10.tgz",
-            "integrity": "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+            "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2249,7 +2287,9 @@
                 "is-array-buffer": "^3.0.5",
                 "is-callable": "^1.2.7",
                 "is-data-view": "^1.0.2",
+                "is-negative-zero": "^2.0.3",
                 "is-regex": "^1.2.1",
+                "is-set": "^2.0.3",
                 "is-shared-array-buffer": "^1.0.4",
                 "is-string": "^1.1.1",
                 "is-typed-array": "^1.1.15",
@@ -2264,6 +2304,7 @@
                 "safe-push-apply": "^1.0.0",
                 "safe-regex-test": "^1.1.0",
                 "set-proto": "^1.0.0",
+                "stop-iteration-iterator": "^1.1.0",
                 "string.prototype.trim": "^1.2.10",
                 "string.prototype.trimend": "^1.0.9",
                 "string.prototype.trimstart": "^1.0.8",
@@ -3452,6 +3493,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4321,9 +4375,9 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
+            "integrity": "sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -5459,9 +5513,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.28.4",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
-            "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
+            "version": "0.28.5",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
+            "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5523,15 +5577,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.32.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
-            "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+            "version": "8.33.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.33.0.tgz",
+            "integrity": "sha512-5YmNhF24ylCsvdNW2oJwMzTbaeO4bg90KeGtMjUw0AGtHksgEPLRTUil+coHwCfiu4QjVJFnjp94DmU6zV7DhQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.32.1",
-                "@typescript-eslint/parser": "8.32.1",
-                "@typescript-eslint/utils": "8.32.1"
+                "@typescript-eslint/eslint-plugin": "8.33.0",
+                "@typescript-eslint/parser": "8.33.0",
+                "@typescript-eslint/utils": "8.33.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/test/from_geojson.test.ts
+++ b/test/from_geojson.test.ts
@@ -171,7 +171,7 @@ test('CoT.from_geojson - Start', (t) => {
     t.ok(+new Date(geo.raw.event._attributes.time) < +new Date() + 100);
 
     // Approx +/- 100ms +1hr20s ahead of now
-    t.ok(+new Date(geo.raw.event._attributes.stale) > +new Date(geo.raw.event._attributes.start) - 100 + 20 * 1000);
+    t.ok(+new Date(geo.raw.event._attributes.stale) > +new Date(geo.raw.event._attributes.time) - 100 + 20 * 1000);
     t.ok(+new Date(geo.raw.event._attributes.stale) < +new Date(geo.raw.event._attributes.start) + 100 + 20 * 1000);
 
     t.end();
@@ -200,7 +200,7 @@ test('CoT.from_geojson - Start/Stale', (t) => {
     t.ok(+new Date(geo.raw.event._attributes.time) < +new Date() + 100);
 
     // Approx +/- 100ms +1hr60s ahead of now
-    t.ok(+new Date(geo.raw.event._attributes.stale) > +new Date(geo.raw.event._attributes.start) - 100 + 60 * 1000);
+    t.ok(+new Date(geo.raw.event._attributes.stale) > +new Date(geo.raw.event._attributes.time) - 100 + 60 * 1000);
     t.ok(+new Date(geo.raw.event._attributes.stale) < +new Date(geo.raw.event._attributes.start) + 100 + 60 * 1000);
 
     t.end();
@@ -309,7 +309,7 @@ test('CoT.from_geojson - Remarks', (t) => {
             coordinates: [1.1, 2.2]
         }
     })
-    
+
     if (!cot.raw.event.detail || !cot.raw.event.detail.remarks) {
         t.fail('No Detail Section')
     } else {


### PR DESCRIPTION
### Context

This PR changes the behavior of `stale` calculation in the COT Utility class to uniformly use `time` as the reference point to calculate stale values.

`start` has mostly been ignored in ETLs until WildWeb@4.3 which introduced using the fire start time as the `start` value which resulted in the `stale` value being days in the past. As this is likely a fairly common issue, all `stale` values are now calculated from the current time unless explicitly set as most TAK clients will not show COT markers that have already staled out.