### PR TITLE
Migrate to UUID

### DIFF
--- a/lib/builders/chat.ts
+++ b/lib/builders/chat.ts
@@ -2,7 +2,7 @@ import Util from '../utils/util.js'
 import CoT from '../cot.js';
 import type JSONCoT from '../types/types.js';
 import type { Static } from '@sinclair/typebox';
-import { randomUUID } from 'node:crypto';
+import { v4 as randomUUID } from 'uuid';
 
 export type DirectChatMember = {
     uid: string;

--- a/lib/cot.ts
+++ b/lib/cot.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto';
+import { v4 as randomUUID } from 'uuid';
 import Err from '@openaddresses/batch-error';
 import type { Static } from '@sinclair/typebox';
 import type {
@@ -179,7 +179,7 @@ export default class CoT {
         } else if (video.uid && connection && !connection.uid) {
             connection.uid = video.uid;
         } else if (!video.uid) {
-            video.uid = crypto.randomUUID();
+            video.uid = randomUUID();
         }
 
         detail.__video = {

--- a/lib/data-package.ts
+++ b/lib/data-package.ts
@@ -7,7 +7,7 @@ import Err from '@openaddresses/batch-error';
 import archiver from 'archiver';
 import StreamZip from 'node-stream-zip'
 import { Readable } from 'node:stream';
-import { randomUUID } from 'node:crypto';
+import { v4 as randomUUID } from 'uuid';
 import CoT from './cot.js';
 import { CoTParser } from './parser.js';
 import xmljs from 'xml-js';

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -2,7 +2,7 @@ import protobuf from 'protobufjs';
 import Err from '@openaddresses/batch-error';
 import { xml2js, js2xml } from 'xml-js';
 import { diff } from 'json-diff-ts';
-import crypto from 'node:crypto';
+import { v4 as randomUUID } from 'uuid';
 import type { Static } from '@sinclair/typebox';
 import type {
     Feature,
@@ -862,7 +862,7 @@ export class CoTParser {
                     cot.event.detail.link.push({
                         _attributes: {
                             type: 'b-m-p-c',
-                            uid: crypto.randomUUID(),
+                            uid: randomUUID(),
                             callsign: "",
                             point: `${coord[1]},${coord[0]}`
                         }

--- a/lib/utils/util.ts
+++ b/lib/utils/util.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto'
+import { v4 as randomUUID } from 'uuid';
 import type { Static } from '@sinclair/typebox';
 import type {
     EventAttributes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "node-stream-zip": "^1.15.0",
                 "protobufjs": "^7.3.0",
                 "rimraf": "^6.0.0",
+                "uuid": "^11.1.0",
                 "xml-js": "^1.6.11"
             },
             "devDependencies": {
@@ -6058,6 +6059,19 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "node-stream-zip": "^1.15.0",
         "protobufjs": "^7.3.0",
         "rimraf": "^6.0.0",
+        "uuid": "^11.1.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {


### PR DESCRIPTION
### Context

Migrate to use the UUID library as node:crypto can't be used in a web context