### PR TITLE
MissionChange.contentUid Optional

### DIFF
--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -310,7 +310,7 @@ export const MissionChangeDetails = Type.Object({
 })
 
 export const MissionChange = Type.Object({
-    contentUid: GenericText,
+    contentUid: Type.Optional(GenericText),
     creatorUid: GenericOptionalText,
     isFederatedChange: GenericText,
     missionName: GenericText,


### PR DESCRIPTION
### Context

Make MissionChange.contentUid optional based on observed behavior in TAK 5.5